### PR TITLE
Implement site scaffold and homepage layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,4 +76,4 @@ storybook-static/
 types/
 
 # Optional: ignore static assets cache
-public/assets/
+

--- a/public/styles/global.css
+++ b/public/styles/global.css
@@ -1,0 +1,13 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+header nav ul {
+  display: flex;
+  list-style: none;
+  padding: 0;
+}
+header nav ul li {
+  margin-right: 1rem;
+}

--- a/src/components/AnalysisBlock.astro
+++ b/src/components/AnalysisBlock.astro
@@ -1,0 +1,5 @@
+---
+---
+<section class="analysis-block">
+  <slot />
+</section>

--- a/src/components/AssistantReview.astro
+++ b/src/components/AssistantReview.astro
@@ -1,0 +1,5 @@
+---
+---
+<div class="assistant-review">
+  <slot />
+</div>

--- a/src/components/GlossaryEntry.astro
+++ b/src/components/GlossaryEntry.astro
@@ -1,0 +1,5 @@
+---
+---
+<article class="glossary-entry">
+  <slot />
+</article>

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -1,0 +1,30 @@
+---
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Benched.ai</title>
+    <link rel="stylesheet" href="/styles/global.css" />
+  </head>
+  <body>
+    <header>
+      <h1><a href="/">Benched.ai</a></h1>
+      <nav>
+        <ul>
+          <li><a href="/benchmarks/">Benchmarks</a></li>
+          <li><a href="/providers/">Providers</a></li>
+          <li><a href="/models/">Models</a></li>
+          <li><a href="/assistants/">Assistants</a></li>
+          <li><a href="/tools/">Tools</a></li>
+          <li><a href="/mcp/">MCP</a></li>
+          <li><a href="/blog/">Blog</a></li>
+          <li><a href="/glossary/">Glossary</a></li>
+        </ul>
+      </nav>
+    </header>
+    <main>
+      <slot />
+    </main>
+  </body>
+</html>

--- a/src/components/McpReview.astro
+++ b/src/components/McpReview.astro
@@ -1,0 +1,5 @@
+---
+---
+<div class="mcp-review">
+  <slot />
+</div>

--- a/src/components/ModelCard.astro
+++ b/src/components/ModelCard.astro
@@ -1,0 +1,5 @@
+---
+---
+<div class="model-card">
+  <slot />
+</div>

--- a/src/components/ProviderCard.astro
+++ b/src/components/ProviderCard.astro
@@ -1,0 +1,5 @@
+---
+---
+<div class="provider-card">
+  <slot />
+</div>

--- a/src/components/ToolReview.astro
+++ b/src/components/ToolReview.astro
@@ -1,0 +1,5 @@
+---
+---
+<div class="tool-review">
+  <slot />
+</div>

--- a/src/content/assistants/assistant-sample.md
+++ b/src/content/assistants/assistant-sample.md
@@ -1,0 +1,1 @@
+# Assistant Sample

--- a/src/content/benchmarks/benchmark-sample.md
+++ b/src/content/benchmarks/benchmark-sample.md
@@ -1,0 +1,1 @@
+# Benchmark Sample

--- a/src/content/blog/blog-sample.md
+++ b/src/content/blog/blog-sample.md
@@ -1,0 +1,1 @@
+# Blog Sample

--- a/src/content/mcp/mcp-sample.md
+++ b/src/content/mcp/mcp-sample.md
@@ -1,0 +1,1 @@
+# MCP Sample

--- a/src/content/models/model-sample.md
+++ b/src/content/models/model-sample.md
@@ -1,0 +1,1 @@
+# Model Sample

--- a/src/content/providers/provider-sample.md
+++ b/src/content/providers/provider-sample.md
@@ -1,0 +1,1 @@
+# Provider Sample

--- a/src/content/tools/tool-sample.md
+++ b/src/content/tools/tool-sample.md
@@ -1,0 +1,1 @@
+# Tool Sample

--- a/src/pages/assistants/[assistant].astro
+++ b/src/pages/assistants/[assistant].astro
@@ -1,0 +1,7 @@
+---
+import Layout from '../../components/Layout.astro'
+---
+
+<Layout>
+  <p>Placeholder detail page.</p>
+</Layout>

--- a/src/pages/assistants/index.astro
+++ b/src/pages/assistants/index.astro
@@ -1,0 +1,9 @@
+---
+import Layout from '../../components/Layout.astro'
+title: Assistants Page
+---
+
+<Layout>
+  <h2>Assistants</h2>
+  <p>Assistants page content.</p>
+</Layout>

--- a/src/pages/benchmarks/[benchmark].astro
+++ b/src/pages/benchmarks/[benchmark].astro
@@ -1,0 +1,7 @@
+---
+import Layout from '../../components/Layout.astro'
+---
+
+<Layout>
+  <p>Placeholder detail page.</p>
+</Layout>

--- a/src/pages/benchmarks/index.astro
+++ b/src/pages/benchmarks/index.astro
@@ -1,0 +1,9 @@
+---
+import Layout from '../../components/Layout.astro'
+title: Benchmarks Page
+---
+
+<Layout>
+  <h2>Benchmarks</h2>
+  <p>Benchmarks page content.</p>
+</Layout>

--- a/src/pages/blog/[post].astro
+++ b/src/pages/blog/[post].astro
@@ -1,0 +1,7 @@
+---
+import Layout from '../../components/Layout.astro'
+---
+
+<Layout>
+  <p>Placeholder detail page.</p>
+</Layout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,9 @@
+---
+import Layout from '../../components/Layout.astro'
+title: Blog Page
+---
+
+<Layout>
+  <h2>Blog</h2>
+  <p>Blog page content.</p>
+</Layout>

--- a/src/pages/glossary/[term].astro
+++ b/src/pages/glossary/[term].astro
@@ -1,0 +1,7 @@
+---
+import Layout from '../../components/Layout.astro'
+---
+
+<Layout>
+  <p>Placeholder detail page.</p>
+</Layout>

--- a/src/pages/glossary/index.astro
+++ b/src/pages/glossary/index.astro
@@ -1,0 +1,9 @@
+---
+import Layout from '../../components/Layout.astro'
+title: Glossary Page
+---
+
+<Layout>
+  <h2>Glossary</h2>
+  <p>Glossary page content.</p>
+</Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,16 +1,8 @@
 ---
-
+import Layout from '../components/Layout.astro'
 ---
 
-<html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="viewport" content="width=device-width" />
-		<meta name="generator" content={Astro.generator} />
-		<title>Astro</title>
-	</head>
-	<body>
-		<h1>Astro</h1>
-	</body>
-</html>
+<Layout>
+  <h2>Welcome to Benched.ai</h2>
+  <p>Your source for independent AI benchmarks and reviews.</p>
+</Layout>

--- a/src/pages/mcp/[protocol].astro
+++ b/src/pages/mcp/[protocol].astro
@@ -1,0 +1,7 @@
+---
+import Layout from '../../components/Layout.astro'
+---
+
+<Layout>
+  <p>Placeholder detail page.</p>
+</Layout>

--- a/src/pages/mcp/index.astro
+++ b/src/pages/mcp/index.astro
@@ -1,0 +1,9 @@
+---
+import Layout from '../../components/Layout.astro'
+title: MCP Page
+---
+
+<Layout>
+  <h2>MCP</h2>
+  <p>MCP page content.</p>
+</Layout>

--- a/src/pages/models/[model].astro
+++ b/src/pages/models/[model].astro
@@ -1,0 +1,7 @@
+---
+import Layout from '../../components/Layout.astro'
+---
+
+<Layout>
+  <p>Placeholder detail page.</p>
+</Layout>

--- a/src/pages/models/index.astro
+++ b/src/pages/models/index.astro
@@ -1,0 +1,9 @@
+---
+import Layout from '../../components/Layout.astro'
+title: Models Page
+---
+
+<Layout>
+  <h2>Models</h2>
+  <p>Models page content.</p>
+</Layout>

--- a/src/pages/providers/[provider].astro
+++ b/src/pages/providers/[provider].astro
@@ -1,0 +1,7 @@
+---
+import Layout from '../../components/Layout.astro'
+---
+
+<Layout>
+  <p>Placeholder detail page.</p>
+</Layout>

--- a/src/pages/providers/index.astro
+++ b/src/pages/providers/index.astro
@@ -1,0 +1,9 @@
+---
+import Layout from '../../components/Layout.astro'
+title: Providers Page
+---
+
+<Layout>
+  <h2>Providers</h2>
+  <p>Providers page content.</p>
+</Layout>

--- a/src/pages/tools/[tool].astro
+++ b/src/pages/tools/[tool].astro
@@ -1,0 +1,7 @@
+---
+import Layout from '../../components/Layout.astro'
+---
+
+<Layout>
+  <p>Placeholder detail page.</p>
+</Layout>

--- a/src/pages/tools/index.astro
+++ b/src/pages/tools/index.astro
@@ -1,0 +1,9 @@
+---
+import Layout from '../../components/Layout.astro'
+title: Tools Page
+---
+
+<Layout>
+  <h2>Tools</h2>
+  <p>Tools page content.</p>
+</Layout>


### PR DESCRIPTION
## Summary
- scaffold site folders and placeholder content from the plan
- add layout component with basic navigation
- create placeholder pages and sample markdown content
- add global CSS and update `.gitignore`
- update homepage to use the new layout

## Testing
- `npm run build` *(fails: astro not installed)*