### PR TITLE
Fix Astro build errors

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -1,2 +1,6 @@
 # Release Notes
 
+## Next
+- Fixed build errors by converting page frontmatter to valid JavaScript and
+  adding empty `getStaticPaths()` functions for placeholder dynamic routes.
+

--- a/src/pages/assistants/[assistant].astro
+++ b/src/pages/assistants/[assistant].astro
@@ -1,5 +1,8 @@
 ---
-import Layout from '../../components/Layout.astro'
+import Layout from '../../components/Layout.astro';
+export async function getStaticPaths() {
+  return [];
+}
 ---
 
 <Layout>

--- a/src/pages/assistants/index.astro
+++ b/src/pages/assistants/index.astro
@@ -1,6 +1,6 @@
 ---
-import Layout from '../../components/Layout.astro'
-title: Assistants Page
+import Layout from '../../components/Layout.astro';
+export const title = 'Assistants Page';
 ---
 
 <Layout>

--- a/src/pages/benchmarks/[benchmark].astro
+++ b/src/pages/benchmarks/[benchmark].astro
@@ -1,5 +1,8 @@
 ---
-import Layout from '../../components/Layout.astro'
+import Layout from '../../components/Layout.astro';
+export async function getStaticPaths() {
+  return [];
+}
 ---
 
 <Layout>

--- a/src/pages/benchmarks/index.astro
+++ b/src/pages/benchmarks/index.astro
@@ -1,6 +1,6 @@
 ---
-import Layout from '../../components/Layout.astro'
-title: Benchmarks Page
+import Layout from '../../components/Layout.astro';
+export const title = 'Benchmarks Page';
 ---
 
 <Layout>

--- a/src/pages/blog/[post].astro
+++ b/src/pages/blog/[post].astro
@@ -1,5 +1,8 @@
 ---
-import Layout from '../../components/Layout.astro'
+import Layout from '../../components/Layout.astro';
+export async function getStaticPaths() {
+  return [];
+}
 ---
 
 <Layout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,6 +1,6 @@
 ---
-import Layout from '../../components/Layout.astro'
-title: Blog Page
+import Layout from '../../components/Layout.astro';
+export const title = 'Blog Page';
 ---
 
 <Layout>

--- a/src/pages/glossary/[term].astro
+++ b/src/pages/glossary/[term].astro
@@ -1,5 +1,8 @@
 ---
-import Layout from '../../components/Layout.astro'
+import Layout from '../../components/Layout.astro';
+export async function getStaticPaths() {
+  return [];
+}
 ---
 
 <Layout>

--- a/src/pages/glossary/index.astro
+++ b/src/pages/glossary/index.astro
@@ -1,6 +1,6 @@
 ---
-import Layout from '../../components/Layout.astro'
-title: Glossary Page
+import Layout from '../../components/Layout.astro';
+export const title = 'Glossary Page';
 ---
 
 <Layout>

--- a/src/pages/mcp/[protocol].astro
+++ b/src/pages/mcp/[protocol].astro
@@ -1,5 +1,8 @@
 ---
-import Layout from '../../components/Layout.astro'
+import Layout from '../../components/Layout.astro';
+export async function getStaticPaths() {
+  return [];
+}
 ---
 
 <Layout>

--- a/src/pages/mcp/index.astro
+++ b/src/pages/mcp/index.astro
@@ -1,6 +1,6 @@
 ---
-import Layout from '../../components/Layout.astro'
-title: MCP Page
+import Layout from '../../components/Layout.astro';
+export const title = 'MCP Page';
 ---
 
 <Layout>

--- a/src/pages/models/[model].astro
+++ b/src/pages/models/[model].astro
@@ -1,5 +1,8 @@
 ---
-import Layout from '../../components/Layout.astro'
+import Layout from '../../components/Layout.astro';
+export async function getStaticPaths() {
+  return [];
+}
 ---
 
 <Layout>

--- a/src/pages/models/index.astro
+++ b/src/pages/models/index.astro
@@ -1,6 +1,6 @@
 ---
-import Layout from '../../components/Layout.astro'
-title: Models Page
+import Layout from '../../components/Layout.astro';
+export const title = 'Models Page';
 ---
 
 <Layout>

--- a/src/pages/providers/[provider].astro
+++ b/src/pages/providers/[provider].astro
@@ -1,5 +1,8 @@
 ---
-import Layout from '../../components/Layout.astro'
+import Layout from '../../components/Layout.astro';
+export async function getStaticPaths() {
+  return [];
+}
 ---
 
 <Layout>

--- a/src/pages/providers/index.astro
+++ b/src/pages/providers/index.astro
@@ -1,6 +1,6 @@
 ---
-import Layout from '../../components/Layout.astro'
-title: Providers Page
+import Layout from '../../components/Layout.astro';
+export const title = 'Providers Page';
 ---
 
 <Layout>

--- a/src/pages/tools/[tool].astro
+++ b/src/pages/tools/[tool].astro
@@ -1,5 +1,8 @@
 ---
-import Layout from '../../components/Layout.astro'
+import Layout from '../../components/Layout.astro';
+export async function getStaticPaths() {
+  return [];
+}
 ---
 
 <Layout>

--- a/src/pages/tools/index.astro
+++ b/src/pages/tools/index.astro
@@ -1,6 +1,6 @@
 ---
-import Layout from '../../components/Layout.astro'
-title: Tools Page
+import Layout from '../../components/Layout.astro';
+export const title = 'Tools Page';
 ---
 
 <Layout>


### PR DESCRIPTION
## Summary
- correct page frontmatter syntax
- add empty `getStaticPaths()` on placeholder dynamic pages
- document the fix in release notes

## Testing
- `npm run build`