### PR TITLE
Fix ESLint config

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,31 +1,37 @@
-// Assuming 'compat' and 'astroPlugin' are imported correctly
 const { FlatCompat } = require("@eslint/eslintrc");
+const js = require("@eslint/js");
 const astroPlugin = require("eslint-plugin-astro");
 
+const compat = new FlatCompat({
+  recommendedConfig: js.configs.recommended,
+  baseDirectory: __dirname,
+});
 
 module.exports = [
-  // Ignore common output and dependency directories
+  // Ignore output and dependency directories
   {
-    ignores: ["node_modules/**", "dist/**"],
+    ignores: ["node_modules/**", "dist/**", "eslint.config.cjs", ".astro/**"],
   },
-  // Extend recommended configurations for ESLint and TypeScript
-  ...compat.extends("eslint:recommended", "plugin:@typescript-eslint/recommended"),
-  // Custom rules for JavaScript and TypeScript files
+  // Extend built-in and TypeScript recommended configs
+  ...compat.extends(
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:astro/recommended"
+  ),
+  // Rules for JavaScript and TypeScript files
   {
     files: ["**/*.{js,ts}"],
     rules: {
       semi: ["error", "never"],
     },
   },
-  // Include Astro plugin's recommended flat config as top-level array entries
-  ...astroPlugin.configs["flat/recommended"],
-  // Override specific rules for Astro files
+  // Astro-specific overrides
   {
     files: ["**/*.astro"],
     rules: {
       "no-unused-labels": "off",
-      "semi": "off", // Disable the generic semi rule to avoid conflicts
-      "astro/semi": ["error", "never"], // Use Astro-specific semi rule
+      semi: "off", // Disable generic semi rule
+      "astro/semi": ["error", "never"],
     },
   },
 ];

--- a/release-notes.md
+++ b/release-notes.md
@@ -8,3 +8,4 @@
 - Added pages listing 32 inference providers.
 - Disabled the `no-unused-labels` rule for Astro files and reverted pages to `title:` frontmatter.
 - Fixed ESLint script to use existing configuration and updated pre-commit hook.
+- Updated ESLint configuration to use flat setup with Astro support.


### PR DESCRIPTION
## Summary
- use flat `eslint.config.cjs` setup with `FlatCompat`
- ignore build artefacts and config file from ESLint
- document the new ESLint configuration in release notes

## Testing
- `pnpm run lint`
- `pnpm run build`
