### PR TITLE
Add provider template and content placeholders

### DIFF
--- a/plan/provider-pages.md
+++ b/plan/provider-pages.md
@@ -1,0 +1,21 @@
+# Plan: Provider detail pages
+
+## Goal
+Create a template for provider pages with predefined sections and add Markdown
+files for each provider so content can be expanded later.
+
+## Steps
+1. Update `src/pages/providers/[provider].astro`.
+   - Load provider info from `providers.ts`.
+   - Dynamically import Markdown from `src/content/providers/{slug}.md` using
+     `import.meta.glob`.
+   - Render the Markdown if it exists followed by section headings:
+     "Intelligence Evaluations", "Context Window", "JSON Mode & Function Calling",
+     "Pricing", "Performance Summary", "Speed", "Latency",
+     "End-to-End Response Time".
+   - Provide placeholder paragraphs for now.
+2. Generate Markdown files for every provider listed in `providers.ts` in the
+   `src/content/providers/` directory. Each file should have a top-level heading
+   with the provider name and a short placeholder sentence.
+3. Run `pnpm run lint` and `pnpm run build` to ensure the site compiles.
+4. Update `release-notes.md` with a summary of the new provider pages.

--- a/release-notes.md
+++ b/release-notes.md
@@ -9,3 +9,4 @@
 - Disabled the `no-unused-labels` rule for Astro files and reverted pages to `title:` frontmatter.
 - Fixed ESLint script to use existing configuration and updated pre-commit hook.
 - Updated ESLint configuration to use flat setup with Astro support.
+- Added provider detail template with standard sections and placeholder Markdown files for each provider.

--- a/src/content/providers/ai21-labs.md
+++ b/src/content/providers/ai21-labs.md
@@ -1,0 +1,3 @@
+# AI21 Labs
+
+Content about AI21 Labs coming soon.

--- a/src/content/providers/alibaba-cloud.md
+++ b/src/content/providers/alibaba-cloud.md
@@ -1,0 +1,3 @@
+# Alibaba Cloud
+
+Content about Alibaba Cloud coming soon.

--- a/src/content/providers/amazon-bedrock.md
+++ b/src/content/providers/amazon-bedrock.md
@@ -1,0 +1,3 @@
+# Amazon Bedrock
+
+Content about Amazon Bedrock coming soon.

--- a/src/content/providers/anthropic.md
+++ b/src/content/providers/anthropic.md
@@ -1,0 +1,3 @@
+# Anthropic
+
+Content about Anthropic coming soon.

--- a/src/content/providers/centml.md
+++ b/src/content/providers/centml.md
@@ -1,0 +1,3 @@
+# CentML
+
+Content about CentML coming soon.

--- a/src/content/providers/cerebras.md
+++ b/src/content/providers/cerebras.md
@@ -1,0 +1,3 @@
+# Cerebras
+
+Content about Cerebras coming soon.

--- a/src/content/providers/cohere.md
+++ b/src/content/providers/cohere.md
@@ -1,0 +1,3 @@
+# Cohere
+
+Content about Cohere coming soon.

--- a/src/content/providers/databricks.md
+++ b/src/content/providers/databricks.md
@@ -1,0 +1,3 @@
+# Databricks
+
+Content about Databricks coming soon.

--- a/src/content/providers/deepinfra.md
+++ b/src/content/providers/deepinfra.md
@@ -1,0 +1,3 @@
+# Deepinfra
+
+Content about Deepinfra coming soon.

--- a/src/content/providers/deepseek.md
+++ b/src/content/providers/deepseek.md
@@ -1,0 +1,3 @@
+# DeepSeek
+
+Content about DeepSeek coming soon.

--- a/src/content/providers/fireworks.md
+++ b/src/content/providers/fireworks.md
@@ -1,0 +1,3 @@
+# Fireworks
+
+Content about Fireworks coming soon.

--- a/src/content/providers/friendliai.md
+++ b/src/content/providers/friendliai.md
@@ -1,0 +1,3 @@
+# FriendliAI
+
+Content about FriendliAI coming soon.

--- a/src/content/providers/google.md
+++ b/src/content/providers/google.md
@@ -1,0 +1,3 @@
+# Google
+
+Content about Google coming soon.

--- a/src/content/providers/groq.md
+++ b/src/content/providers/groq.md
@@ -1,0 +1,3 @@
+# Groq
+
+Content about Groq coming soon.

--- a/src/content/providers/hyperbolic.md
+++ b/src/content/providers/hyperbolic.md
@@ -1,0 +1,3 @@
+# Hyperbolic
+
+Content about Hyperbolic coming soon.

--- a/src/content/providers/kluster-ai.md
+++ b/src/content/providers/kluster-ai.md
@@ -1,0 +1,3 @@
+# kluster.ai
+
+Content about kluster.ai coming soon.

--- a/src/content/providers/lambda-labs.md
+++ b/src/content/providers/lambda-labs.md
@@ -1,0 +1,3 @@
+# Lambda Labs
+
+Content about Lambda Labs coming soon.

--- a/src/content/providers/microsoft-azure.md
+++ b/src/content/providers/microsoft-azure.md
@@ -1,0 +1,3 @@
+# Microsoft Azure
+
+Content about Microsoft Azure coming soon.

--- a/src/content/providers/minimax.md
+++ b/src/content/providers/minimax.md
@@ -1,0 +1,3 @@
+# MiniMax
+
+Content about MiniMax coming soon.

--- a/src/content/providers/mistral.md
+++ b/src/content/providers/mistral.md
@@ -1,0 +1,3 @@
+# Mistral
+
+Content about Mistral coming soon.

--- a/src/content/providers/nebius.md
+++ b/src/content/providers/nebius.md
@@ -1,0 +1,3 @@
+# Nebius
+
+Content about Nebius coming soon.

--- a/src/content/providers/novita.md
+++ b/src/content/providers/novita.md
@@ -1,0 +1,3 @@
+# Novita
+
+Content about Novita coming soon.

--- a/src/content/providers/openai.md
+++ b/src/content/providers/openai.md
@@ -1,0 +1,3 @@
+# OpenAI
+
+Content about OpenAI coming soon.

--- a/src/content/providers/parasail.md
+++ b/src/content/providers/parasail.md
@@ -1,0 +1,3 @@
+# Parasail
+
+Content about Parasail coming soon.

--- a/src/content/providers/perplexity.md
+++ b/src/content/providers/perplexity.md
@@ -1,0 +1,3 @@
+# Perplexity
+
+Content about Perplexity coming soon.

--- a/src/content/providers/reka-ai.md
+++ b/src/content/providers/reka-ai.md
@@ -1,0 +1,3 @@
+# Reka AI
+
+Content about Reka AI coming soon.

--- a/src/content/providers/replicate.md
+++ b/src/content/providers/replicate.md
@@ -1,0 +1,3 @@
+# Replicate
+
+Content about Replicate coming soon.

--- a/src/content/providers/sambanova.md
+++ b/src/content/providers/sambanova.md
@@ -1,0 +1,3 @@
+# SambaNova
+
+Content about SambaNova coming soon.

--- a/src/content/providers/simplismart.md
+++ b/src/content/providers/simplismart.md
@@ -1,0 +1,3 @@
+# Simplismart
+
+Content about Simplismart coming soon.

--- a/src/content/providers/together-ai.md
+++ b/src/content/providers/together-ai.md
@@ -1,0 +1,3 @@
+# Together.ai
+
+Content about Together.ai coming soon.

--- a/src/content/providers/upstage.md
+++ b/src/content/providers/upstage.md
@@ -1,0 +1,3 @@
+# Upstage
+
+Content about Upstage coming soon.

--- a/src/content/providers/xai.md
+++ b/src/content/providers/xai.md
@@ -1,0 +1,3 @@
+# xAI
+
+Content about xAI coming soon.

--- a/src/pages/providers/[provider].astro
+++ b/src/pages/providers/[provider].astro
@@ -6,9 +6,46 @@ export async function getStaticPaths() {
 }
 const { provider } = Astro.params
 const data = providers.find(p => p.slug === provider)
+const pages = import.meta.glob('../../content/providers/*.md')
+let MDContent
+if (pages[`../../content/providers/${provider}.md`]) {
+  MDContent = (await pages[`../../content/providers/${provider}.md`]()).default
+}
 ---
 
 <Layout>
   <h2>{data?.name}</h2>
-  <p>Provider page for {data?.name}.</p>
+  {MDContent ? <MDContent /> : <p>More details coming soon.</p>}
+  <section>
+    <h3>Intelligence Evaluations</h3>
+    <p>Details about intelligence evaluations go here.</p>
+  </section>
+  <section>
+    <h3>Context Window</h3>
+    <p>Information about context window.</p>
+  </section>
+  <section>
+    <h3>JSON Mode & Function Calling</h3>
+    <p>Support for JSON mode and function calling.</p>
+  </section>
+  <section>
+    <h3>Pricing</h3>
+    <p>Pricing information.</p>
+  </section>
+  <section>
+    <h3>Performance Summary</h3>
+    <p>Performance summary.</p>
+  </section>
+  <section>
+    <h3>Speed</h3>
+    <p>Speed metrics.</p>
+  </section>
+  <section>
+    <h3>Latency</h3>
+    <p>Latency metrics.</p>
+  </section>
+  <section>
+    <h3>End-to-End Response Time</h3>
+    <p>End-to-end response time metrics.</p>
+  </section>
 </Layout>


### PR DESCRIPTION
## Summary
- create detailed provider page template with standard sections
- load Markdown content for each provider
- add placeholder Markdown files for all providers
- document the plan and update release notes

## Testing
- `pnpm run lint`
- `pnpm run build`
