### PR TITLE
Fix linter build issue

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -12,3 +12,4 @@
 - Updated ESLint configuration to use flat setup with Astro support.
 - Added placeholder Markdown pages for each assistant.
 - Added provider detail template with standard sections and placeholder Markdown files for each provider.
+- Removed duplicate variable declarations in the assistants page to resolve build errors.

--- a/src/pages/assistants/[assistant].astro
+++ b/src/pages/assistants/[assistant].astro
@@ -1,19 +1,20 @@
 ---
 import Layout from '../../components/Layout.astro'
 import { assistants } from '../../data/assistants'
+
 export async function getStaticPaths() {
   return assistants.map(a => ({ params: { assistant: a.slug } }))
 }
+
 const { assistant } = Astro.params
 const data = assistants.find(a => a.slug === assistant)
+
 const contentModules = import.meta.glob('../../content/assistants/*.md')
 let Content
 if (contentModules[`../../content/assistants/${assistant}.md`]) {
   const mod = await contentModules[`../../content/assistants/${assistant}.md`]()
   Content = mod.default
 }
-const { assistant } = Astro.params
-const data = assistants.find(a => a.slug === assistant)
 ---
 
 <Layout>


### PR DESCRIPTION
## Summary
- remove duplicate declarations in the assistants page
- note fix in release notes

## Testing
- `pnpm run lint`
- `pnpm run build`
