### PR TITLE
Add assistant category metadata

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -15,3 +15,4 @@
 - Removed duplicate variable declarations in the assistants page to resolve build errors.
 - Added dynamic pages for over 100 AI models.
 - Generated placeholder MDX files for all models.
+- Added category metadata to assistant pages for future comparisons.

--- a/src/content/assistants/assistant-sample.md
+++ b/src/content/assistants/assistant-sample.md
@@ -1,1 +1,42 @@
+---
+categories:
+  performance:
+    price: ''
+    foundationModel: ''
+    intelligence: ''
+    rateLimit: ''
+    speed: ''
+    timeToFirstToken: ''
+    outputSpeed: ''
+    contextWindow: ''
+  capabilities:
+    image:
+      imageGeneration: ''
+      imageModel: ''
+      imageModelRanking: ''
+    input:
+      inputCapabilities: ''
+      imageUpload: ''
+      pdfUpload: ''
+      excelCsvUpload: ''
+      fileSourceConnect: ''
+    voice:
+      voiceFeatures: ''
+      voiceInput: ''
+      voiceConversation: ''
+      nativeVoiceToVoice: ''
+    tools: ''
+  memoryHistory:
+    memory: ''
+    chatHistory: ''
+  apps:
+    ios: ''
+    android: ''
+    mac: ''
+    windows: ''
+  other:
+    notes: ''
+    trainingDataSharingPolicy: ''
+    trainingDataSharingPolicySource: ''
+---
 # Assistant Sample

--- a/src/content/assistants/character-ai-free.md
+++ b/src/content/assistants/character-ai-free.md
@@ -1,3 +1,44 @@
+---
+categories:
+  performance:
+    price: ''
+    foundationModel: ''
+    intelligence: ''
+    rateLimit: ''
+    speed: ''
+    timeToFirstToken: ''
+    outputSpeed: ''
+    contextWindow: ''
+  capabilities:
+    image:
+      imageGeneration: ''
+      imageModel: ''
+      imageModelRanking: ''
+    input:
+      inputCapabilities: ''
+      imageUpload: ''
+      pdfUpload: ''
+      excelCsvUpload: ''
+      fileSourceConnect: ''
+    voice:
+      voiceFeatures: ''
+      voiceInput: ''
+      voiceConversation: ''
+      nativeVoiceToVoice: ''
+    tools: ''
+  memoryHistory:
+    memory: ''
+    chatHistory: ''
+  apps:
+    ios: ''
+    android: ''
+    mac: ''
+    windows: ''
+  other:
+    notes: ''
+    trainingDataSharingPolicy: ''
+    trainingDataSharingPolicySource: ''
+---
 # Character AI Free
 
 Content for Character AI Free.

--- a/src/content/assistants/character-ai-plus.md
+++ b/src/content/assistants/character-ai-plus.md
@@ -1,3 +1,44 @@
+---
+categories:
+  performance:
+    price: ''
+    foundationModel: ''
+    intelligence: ''
+    rateLimit: ''
+    speed: ''
+    timeToFirstToken: ''
+    outputSpeed: ''
+    contextWindow: ''
+  capabilities:
+    image:
+      imageGeneration: ''
+      imageModel: ''
+      imageModelRanking: ''
+    input:
+      inputCapabilities: ''
+      imageUpload: ''
+      pdfUpload: ''
+      excelCsvUpload: ''
+      fileSourceConnect: ''
+    voice:
+      voiceFeatures: ''
+      voiceInput: ''
+      voiceConversation: ''
+      nativeVoiceToVoice: ''
+    tools: ''
+  memoryHistory:
+    memory: ''
+    chatHistory: ''
+  apps:
+    ios: ''
+    android: ''
+    mac: ''
+    windows: ''
+  other:
+    notes: ''
+    trainingDataSharingPolicy: ''
+    trainingDataSharingPolicySource: ''
+---
 # Character AI Plus
 
 Content for Character AI Plus.

--- a/src/content/assistants/chatgpt-free-logged-out.md
+++ b/src/content/assistants/chatgpt-free-logged-out.md
@@ -1,3 +1,44 @@
+---
+categories:
+  performance:
+    price: ''
+    foundationModel: ''
+    intelligence: ''
+    rateLimit: ''
+    speed: ''
+    timeToFirstToken: ''
+    outputSpeed: ''
+    contextWindow: ''
+  capabilities:
+    image:
+      imageGeneration: ''
+      imageModel: ''
+      imageModelRanking: ''
+    input:
+      inputCapabilities: ''
+      imageUpload: ''
+      pdfUpload: ''
+      excelCsvUpload: ''
+      fileSourceConnect: ''
+    voice:
+      voiceFeatures: ''
+      voiceInput: ''
+      voiceConversation: ''
+      nativeVoiceToVoice: ''
+    tools: ''
+  memoryHistory:
+    memory: ''
+    chatHistory: ''
+  apps:
+    ios: ''
+    android: ''
+    mac: ''
+    windows: ''
+  other:
+    notes: ''
+    trainingDataSharingPolicy: ''
+    trainingDataSharingPolicySource: ''
+---
 # ChatGPT Free (Logged Out)
 
 Content for ChatGPT Free (Logged Out).

--- a/src/content/assistants/chatgpt-free.md
+++ b/src/content/assistants/chatgpt-free.md
@@ -1,3 +1,44 @@
+---
+categories:
+  performance:
+    price: ''
+    foundationModel: ''
+    intelligence: ''
+    rateLimit: ''
+    speed: ''
+    timeToFirstToken: ''
+    outputSpeed: ''
+    contextWindow: ''
+  capabilities:
+    image:
+      imageGeneration: ''
+      imageModel: ''
+      imageModelRanking: ''
+    input:
+      inputCapabilities: ''
+      imageUpload: ''
+      pdfUpload: ''
+      excelCsvUpload: ''
+      fileSourceConnect: ''
+    voice:
+      voiceFeatures: ''
+      voiceInput: ''
+      voiceConversation: ''
+      nativeVoiceToVoice: ''
+    tools: ''
+  memoryHistory:
+    memory: ''
+    chatHistory: ''
+  apps:
+    ios: ''
+    android: ''
+    mac: ''
+    windows: ''
+  other:
+    notes: ''
+    trainingDataSharingPolicy: ''
+    trainingDataSharingPolicySource: ''
+---
 # ChatGPT Free
 
 Content for ChatGPT Free.

--- a/src/content/assistants/chatgpt-plus.md
+++ b/src/content/assistants/chatgpt-plus.md
@@ -1,3 +1,44 @@
+---
+categories:
+  performance:
+    price: ''
+    foundationModel: ''
+    intelligence: ''
+    rateLimit: ''
+    speed: ''
+    timeToFirstToken: ''
+    outputSpeed: ''
+    contextWindow: ''
+  capabilities:
+    image:
+      imageGeneration: ''
+      imageModel: ''
+      imageModelRanking: ''
+    input:
+      inputCapabilities: ''
+      imageUpload: ''
+      pdfUpload: ''
+      excelCsvUpload: ''
+      fileSourceConnect: ''
+    voice:
+      voiceFeatures: ''
+      voiceInput: ''
+      voiceConversation: ''
+      nativeVoiceToVoice: ''
+    tools: ''
+  memoryHistory:
+    memory: ''
+    chatHistory: ''
+  apps:
+    ios: ''
+    android: ''
+    mac: ''
+    windows: ''
+  other:
+    notes: ''
+    trainingDataSharingPolicy: ''
+    trainingDataSharingPolicySource: ''
+---
 # ChatGPT Plus
 
 Content for ChatGPT Plus.

--- a/src/content/assistants/claude-free.md
+++ b/src/content/assistants/claude-free.md
@@ -1,3 +1,44 @@
+---
+categories:
+  performance:
+    price: ''
+    foundationModel: ''
+    intelligence: ''
+    rateLimit: ''
+    speed: ''
+    timeToFirstToken: ''
+    outputSpeed: ''
+    contextWindow: ''
+  capabilities:
+    image:
+      imageGeneration: ''
+      imageModel: ''
+      imageModelRanking: ''
+    input:
+      inputCapabilities: ''
+      imageUpload: ''
+      pdfUpload: ''
+      excelCsvUpload: ''
+      fileSourceConnect: ''
+    voice:
+      voiceFeatures: ''
+      voiceInput: ''
+      voiceConversation: ''
+      nativeVoiceToVoice: ''
+    tools: ''
+  memoryHistory:
+    memory: ''
+    chatHistory: ''
+  apps:
+    ios: ''
+    android: ''
+    mac: ''
+    windows: ''
+  other:
+    notes: ''
+    trainingDataSharingPolicy: ''
+    trainingDataSharingPolicySource: ''
+---
 # Claude Free
 
 Content for Claude Free.

--- a/src/content/assistants/claude-pro.md
+++ b/src/content/assistants/claude-pro.md
@@ -1,3 +1,44 @@
+---
+categories:
+  performance:
+    price: ''
+    foundationModel: ''
+    intelligence: ''
+    rateLimit: ''
+    speed: ''
+    timeToFirstToken: ''
+    outputSpeed: ''
+    contextWindow: ''
+  capabilities:
+    image:
+      imageGeneration: ''
+      imageModel: ''
+      imageModelRanking: ''
+    input:
+      inputCapabilities: ''
+      imageUpload: ''
+      pdfUpload: ''
+      excelCsvUpload: ''
+      fileSourceConnect: ''
+    voice:
+      voiceFeatures: ''
+      voiceInput: ''
+      voiceConversation: ''
+      nativeVoiceToVoice: ''
+    tools: ''
+  memoryHistory:
+    memory: ''
+    chatHistory: ''
+  apps:
+    ios: ''
+    android: ''
+    mac: ''
+    windows: ''
+  other:
+    notes: ''
+    trainingDataSharingPolicy: ''
+    trainingDataSharingPolicySource: ''
+---
 # Claude Pro
 
 Content for Claude Pro.

--- a/src/content/assistants/gemini-advanced.md
+++ b/src/content/assistants/gemini-advanced.md
@@ -1,3 +1,44 @@
+---
+categories:
+  performance:
+    price: ''
+    foundationModel: ''
+    intelligence: ''
+    rateLimit: ''
+    speed: ''
+    timeToFirstToken: ''
+    outputSpeed: ''
+    contextWindow: ''
+  capabilities:
+    image:
+      imageGeneration: ''
+      imageModel: ''
+      imageModelRanking: ''
+    input:
+      inputCapabilities: ''
+      imageUpload: ''
+      pdfUpload: ''
+      excelCsvUpload: ''
+      fileSourceConnect: ''
+    voice:
+      voiceFeatures: ''
+      voiceInput: ''
+      voiceConversation: ''
+      nativeVoiceToVoice: ''
+    tools: ''
+  memoryHistory:
+    memory: ''
+    chatHistory: ''
+  apps:
+    ios: ''
+    android: ''
+    mac: ''
+    windows: ''
+  other:
+    notes: ''
+    trainingDataSharingPolicy: ''
+    trainingDataSharingPolicySource: ''
+---
 # Gemini Advanced
 
 Content for Gemini Advanced.

--- a/src/content/assistants/gemini-free.md
+++ b/src/content/assistants/gemini-free.md
@@ -1,3 +1,44 @@
+---
+categories:
+  performance:
+    price: ''
+    foundationModel: ''
+    intelligence: ''
+    rateLimit: ''
+    speed: ''
+    timeToFirstToken: ''
+    outputSpeed: ''
+    contextWindow: ''
+  capabilities:
+    image:
+      imageGeneration: ''
+      imageModel: ''
+      imageModelRanking: ''
+    input:
+      inputCapabilities: ''
+      imageUpload: ''
+      pdfUpload: ''
+      excelCsvUpload: ''
+      fileSourceConnect: ''
+    voice:
+      voiceFeatures: ''
+      voiceInput: ''
+      voiceConversation: ''
+      nativeVoiceToVoice: ''
+    tools: ''
+  memoryHistory:
+    memory: ''
+    chatHistory: ''
+  apps:
+    ios: ''
+    android: ''
+    mac: ''
+    windows: ''
+  other:
+    notes: ''
+    trainingDataSharingPolicy: ''
+    trainingDataSharingPolicySource: ''
+---
 # Gemini Free
 
 Content for Gemini Free.

--- a/src/content/assistants/grok.md
+++ b/src/content/assistants/grok.md
@@ -1,3 +1,44 @@
+---
+categories:
+  performance:
+    price: ''
+    foundationModel: ''
+    intelligence: ''
+    rateLimit: ''
+    speed: ''
+    timeToFirstToken: ''
+    outputSpeed: ''
+    contextWindow: ''
+  capabilities:
+    image:
+      imageGeneration: ''
+      imageModel: ''
+      imageModelRanking: ''
+    input:
+      inputCapabilities: ''
+      imageUpload: ''
+      pdfUpload: ''
+      excelCsvUpload: ''
+      fileSourceConnect: ''
+    voice:
+      voiceFeatures: ''
+      voiceInput: ''
+      voiceConversation: ''
+      nativeVoiceToVoice: ''
+    tools: ''
+  memoryHistory:
+    memory: ''
+    chatHistory: ''
+  apps:
+    ios: ''
+    android: ''
+    mac: ''
+    windows: ''
+  other:
+    notes: ''
+    trainingDataSharingPolicy: ''
+    trainingDataSharingPolicySource: ''
+---
 # Grok
 
 Content for Grok.

--- a/src/content/assistants/huggingchat.md
+++ b/src/content/assistants/huggingchat.md
@@ -1,3 +1,44 @@
+---
+categories:
+  performance:
+    price: ''
+    foundationModel: ''
+    intelligence: ''
+    rateLimit: ''
+    speed: ''
+    timeToFirstToken: ''
+    outputSpeed: ''
+    contextWindow: ''
+  capabilities:
+    image:
+      imageGeneration: ''
+      imageModel: ''
+      imageModelRanking: ''
+    input:
+      inputCapabilities: ''
+      imageUpload: ''
+      pdfUpload: ''
+      excelCsvUpload: ''
+      fileSourceConnect: ''
+    voice:
+      voiceFeatures: ''
+      voiceInput: ''
+      voiceConversation: ''
+      nativeVoiceToVoice: ''
+    tools: ''
+  memoryHistory:
+    memory: ''
+    chatHistory: ''
+  apps:
+    ios: ''
+    android: ''
+    mac: ''
+    windows: ''
+  other:
+    notes: ''
+    trainingDataSharingPolicy: ''
+    trainingDataSharingPolicySource: ''
+---
 # HuggingChat
 
 Content for HuggingChat.

--- a/src/content/assistants/meta-ai.md
+++ b/src/content/assistants/meta-ai.md
@@ -1,3 +1,44 @@
+---
+categories:
+  performance:
+    price: ''
+    foundationModel: ''
+    intelligence: ''
+    rateLimit: ''
+    speed: ''
+    timeToFirstToken: ''
+    outputSpeed: ''
+    contextWindow: ''
+  capabilities:
+    image:
+      imageGeneration: ''
+      imageModel: ''
+      imageModelRanking: ''
+    input:
+      inputCapabilities: ''
+      imageUpload: ''
+      pdfUpload: ''
+      excelCsvUpload: ''
+      fileSourceConnect: ''
+    voice:
+      voiceFeatures: ''
+      voiceInput: ''
+      voiceConversation: ''
+      nativeVoiceToVoice: ''
+    tools: ''
+  memoryHistory:
+    memory: ''
+    chatHistory: ''
+  apps:
+    ios: ''
+    android: ''
+    mac: ''
+    windows: ''
+  other:
+    notes: ''
+    trainingDataSharingPolicy: ''
+    trainingDataSharingPolicySource: ''
+---
 # Meta AI
 
 Content for Meta AI.

--- a/src/content/assistants/microsoft-copilot-free.md
+++ b/src/content/assistants/microsoft-copilot-free.md
@@ -1,3 +1,44 @@
+---
+categories:
+  performance:
+    price: ''
+    foundationModel: ''
+    intelligence: ''
+    rateLimit: ''
+    speed: ''
+    timeToFirstToken: ''
+    outputSpeed: ''
+    contextWindow: ''
+  capabilities:
+    image:
+      imageGeneration: ''
+      imageModel: ''
+      imageModelRanking: ''
+    input:
+      inputCapabilities: ''
+      imageUpload: ''
+      pdfUpload: ''
+      excelCsvUpload: ''
+      fileSourceConnect: ''
+    voice:
+      voiceFeatures: ''
+      voiceInput: ''
+      voiceConversation: ''
+      nativeVoiceToVoice: ''
+    tools: ''
+  memoryHistory:
+    memory: ''
+    chatHistory: ''
+  apps:
+    ios: ''
+    android: ''
+    mac: ''
+    windows: ''
+  other:
+    notes: ''
+    trainingDataSharingPolicy: ''
+    trainingDataSharingPolicySource: ''
+---
 # Microsoft Copilot Free
 
 Content for Microsoft Copilot Free.

--- a/src/content/assistants/mistral-le-chat.md
+++ b/src/content/assistants/mistral-le-chat.md
@@ -1,3 +1,44 @@
+---
+categories:
+  performance:
+    price: ''
+    foundationModel: ''
+    intelligence: ''
+    rateLimit: ''
+    speed: ''
+    timeToFirstToken: ''
+    outputSpeed: ''
+    contextWindow: ''
+  capabilities:
+    image:
+      imageGeneration: ''
+      imageModel: ''
+      imageModelRanking: ''
+    input:
+      inputCapabilities: ''
+      imageUpload: ''
+      pdfUpload: ''
+      excelCsvUpload: ''
+      fileSourceConnect: ''
+    voice:
+      voiceFeatures: ''
+      voiceInput: ''
+      voiceConversation: ''
+      nativeVoiceToVoice: ''
+    tools: ''
+  memoryHistory:
+    memory: ''
+    chatHistory: ''
+  apps:
+    ios: ''
+    android: ''
+    mac: ''
+    windows: ''
+  other:
+    notes: ''
+    trainingDataSharingPolicy: ''
+    trainingDataSharingPolicySource: ''
+---
 # Mistral Le Chat
 
 Content for Mistral Le Chat.

--- a/src/content/assistants/perplexity-free.md
+++ b/src/content/assistants/perplexity-free.md
@@ -1,3 +1,44 @@
+---
+categories:
+  performance:
+    price: ''
+    foundationModel: ''
+    intelligence: ''
+    rateLimit: ''
+    speed: ''
+    timeToFirstToken: ''
+    outputSpeed: ''
+    contextWindow: ''
+  capabilities:
+    image:
+      imageGeneration: ''
+      imageModel: ''
+      imageModelRanking: ''
+    input:
+      inputCapabilities: ''
+      imageUpload: ''
+      pdfUpload: ''
+      excelCsvUpload: ''
+      fileSourceConnect: ''
+    voice:
+      voiceFeatures: ''
+      voiceInput: ''
+      voiceConversation: ''
+      nativeVoiceToVoice: ''
+    tools: ''
+  memoryHistory:
+    memory: ''
+    chatHistory: ''
+  apps:
+    ios: ''
+    android: ''
+    mac: ''
+    windows: ''
+  other:
+    notes: ''
+    trainingDataSharingPolicy: ''
+    trainingDataSharingPolicySource: ''
+---
 # Perplexity Free
 
 Content for Perplexity Free.

--- a/src/content/assistants/perplexity-pro.md
+++ b/src/content/assistants/perplexity-pro.md
@@ -1,3 +1,44 @@
+---
+categories:
+  performance:
+    price: ''
+    foundationModel: ''
+    intelligence: ''
+    rateLimit: ''
+    speed: ''
+    timeToFirstToken: ''
+    outputSpeed: ''
+    contextWindow: ''
+  capabilities:
+    image:
+      imageGeneration: ''
+      imageModel: ''
+      imageModelRanking: ''
+    input:
+      inputCapabilities: ''
+      imageUpload: ''
+      pdfUpload: ''
+      excelCsvUpload: ''
+      fileSourceConnect: ''
+    voice:
+      voiceFeatures: ''
+      voiceInput: ''
+      voiceConversation: ''
+      nativeVoiceToVoice: ''
+    tools: ''
+  memoryHistory:
+    memory: ''
+    chatHistory: ''
+  apps:
+    ios: ''
+    android: ''
+    mac: ''
+    windows: ''
+  other:
+    notes: ''
+    trainingDataSharingPolicy: ''
+    trainingDataSharingPolicySource: ''
+---
 # Perplexity Pro
 
 Content for Perplexity Pro.

--- a/src/content/assistants/poe-free.md
+++ b/src/content/assistants/poe-free.md
@@ -1,3 +1,44 @@
+---
+categories:
+  performance:
+    price: ''
+    foundationModel: ''
+    intelligence: ''
+    rateLimit: ''
+    speed: ''
+    timeToFirstToken: ''
+    outputSpeed: ''
+    contextWindow: ''
+  capabilities:
+    image:
+      imageGeneration: ''
+      imageModel: ''
+      imageModelRanking: ''
+    input:
+      inputCapabilities: ''
+      imageUpload: ''
+      pdfUpload: ''
+      excelCsvUpload: ''
+      fileSourceConnect: ''
+    voice:
+      voiceFeatures: ''
+      voiceInput: ''
+      voiceConversation: ''
+      nativeVoiceToVoice: ''
+    tools: ''
+  memoryHistory:
+    memory: ''
+    chatHistory: ''
+  apps:
+    ios: ''
+    android: ''
+    mac: ''
+    windows: ''
+  other:
+    notes: ''
+    trainingDataSharingPolicy: ''
+    trainingDataSharingPolicySource: ''
+---
 # Poe Free
 
 Content for Poe Free.

--- a/src/content/assistants/poe-pro.md
+++ b/src/content/assistants/poe-pro.md
@@ -1,3 +1,44 @@
+---
+categories:
+  performance:
+    price: ''
+    foundationModel: ''
+    intelligence: ''
+    rateLimit: ''
+    speed: ''
+    timeToFirstToken: ''
+    outputSpeed: ''
+    contextWindow: ''
+  capabilities:
+    image:
+      imageGeneration: ''
+      imageModel: ''
+      imageModelRanking: ''
+    input:
+      inputCapabilities: ''
+      imageUpload: ''
+      pdfUpload: ''
+      excelCsvUpload: ''
+      fileSourceConnect: ''
+    voice:
+      voiceFeatures: ''
+      voiceInput: ''
+      voiceConversation: ''
+      nativeVoiceToVoice: ''
+    tools: ''
+  memoryHistory:
+    memory: ''
+    chatHistory: ''
+  apps:
+    ios: ''
+    android: ''
+    mac: ''
+    windows: ''
+  other:
+    notes: ''
+    trainingDataSharingPolicy: ''
+    trainingDataSharingPolicySource: ''
+---
 # Poe Pro
 
 Content for Poe Pro.

--- a/src/data/assistants.ts
+++ b/src/data/assistants.ts
@@ -1,20 +1,73 @@
+const categoriesTemplate = {
+  performance: {
+    price: '',
+    foundationModel: '',
+    intelligence: '',
+    rateLimit: '',
+    speed: '',
+    timeToFirstToken: '',
+    outputSpeed: '',
+    contextWindow: ''
+  },
+  capabilities: {
+    image: {
+      imageGeneration: '',
+      imageModel: '',
+      imageModelRanking: ''
+    },
+    input: {
+      inputCapabilities: '',
+      imageUpload: '',
+      pdfUpload: '',
+      excelCsvUpload: '',
+      fileSourceConnect: ''
+    },
+    voice: {
+      voiceFeatures: '',
+      voiceInput: '',
+      voiceConversation: '',
+      nativeVoiceToVoice: ''
+    },
+    tools: ''
+  },
+  memoryHistory: {
+    memory: '',
+    chatHistory: ''
+  },
+  apps: {
+    ios: '',
+    android: '',
+    mac: '',
+    windows: ''
+  },
+  other: {
+    notes: '',
+    trainingDataSharingPolicy: '',
+    trainingDataSharingPolicySource: ''
+  }
+}
+
+function cloneCategories() {
+  return JSON.parse(JSON.stringify(categoriesTemplate))
+}
+
 export const assistants = [
-  { slug: 'chatgpt-plus', name: 'ChatGPT Plus' },
-  { slug: 'chatgpt-free', name: 'ChatGPT Free' },
-  { slug: 'claude-pro', name: 'Claude Pro' },
-  { slug: 'claude-free', name: 'Claude Free' },
-  { slug: 'gemini-advanced', name: 'Gemini Advanced' },
-  { slug: 'gemini-free', name: 'Gemini Free' },
-  { slug: 'poe-pro', name: 'Poe Pro' },
-  { slug: 'poe-free', name: 'Poe Free' },
-  { slug: 'perplexity-pro', name: 'Perplexity Pro' },
-  { slug: 'perplexity-free', name: 'Perplexity Free' },
-  { slug: 'microsoft-copilot-free', name: 'Microsoft Copilot Free' },
-  { slug: 'meta-ai', name: 'Meta AI' },
-  { slug: 'grok', name: 'Grok' },
-  { slug: 'mistral-le-chat', name: 'Mistral Le Chat' },
-  { slug: 'huggingchat', name: 'HuggingChat' },
-  { slug: 'character-ai-plus', name: 'Character AI Plus' },
-  { slug: 'character-ai-free', name: 'Character AI Free' },
-  { slug: 'chatgpt-free-logged-out', name: 'ChatGPT Free (Logged Out)' },
+  { slug: 'chatgpt-plus', name: 'ChatGPT Plus', categories: cloneCategories() },
+  { slug: 'chatgpt-free', name: 'ChatGPT Free', categories: cloneCategories() },
+  { slug: 'claude-pro', name: 'Claude Pro', categories: cloneCategories() },
+  { slug: 'claude-free', name: 'Claude Free', categories: cloneCategories() },
+  { slug: 'gemini-advanced', name: 'Gemini Advanced', categories: cloneCategories() },
+  { slug: 'gemini-free', name: 'Gemini Free', categories: cloneCategories() },
+  { slug: 'poe-pro', name: 'Poe Pro', categories: cloneCategories() },
+  { slug: 'poe-free', name: 'Poe Free', categories: cloneCategories() },
+  { slug: 'perplexity-pro', name: 'Perplexity Pro', categories: cloneCategories() },
+  { slug: 'perplexity-free', name: 'Perplexity Free', categories: cloneCategories() },
+  { slug: 'microsoft-copilot-free', name: 'Microsoft Copilot Free', categories: cloneCategories() },
+  { slug: 'meta-ai', name: 'Meta AI', categories: cloneCategories() },
+  { slug: 'grok', name: 'Grok', categories: cloneCategories() },
+  { slug: 'mistral-le-chat', name: 'Mistral Le Chat', categories: cloneCategories() },
+  { slug: 'huggingchat', name: 'HuggingChat', categories: cloneCategories() },
+  { slug: 'character-ai-plus', name: 'Character AI Plus', categories: cloneCategories() },
+  { slug: 'character-ai-free', name: 'Character AI Free', categories: cloneCategories() },
+  { slug: 'chatgpt-free-logged-out', name: 'ChatGPT Free (Logged Out)', categories: cloneCategories() },
 ]

--- a/src/pages/assistants/[assistant].astro
+++ b/src/pages/assistants/[assistant].astro
@@ -11,13 +11,18 @@ const data = assistants.find(a => a.slug === assistant)
 
 const contentModules = import.meta.glob('../../content/assistants/*.md')
 let Content
+let metadata
 if (contentModules[`../../content/assistants/${assistant}.md`]) {
   const mod = await contentModules[`../../content/assistants/${assistant}.md`]()
   Content = mod.default
+  metadata = mod.frontmatter
 }
 ---
 
 <Layout>
   <h2>{data?.name}</h2>
+  {metadata?.categories && (
+    <pre>{JSON.stringify(metadata.categories, null, 2)}</pre>
+  )}
   {Content ? <Content /> : <p>Assistant page for {data?.name}.</p>}
 </Layout>


### PR DESCRIPTION
## Summary
- extend assistant pages with detailed category metadata for comparison
- expose frontmatter metadata in dynamic assistant page
- document changes in release notes

## Testing
- `pnpm run lint`
- `pnpm run build`
